### PR TITLE
PPLUS-1866: Fix the manifests, add array keys

### DIFF
--- a/SprykerShop/CmsContentWidgetProductConnector/1.0.0/installer-manifest.json
+++ b/SprykerShop/CmsContentWidgetProductConnector/1.0.0/installer-manifest.json
@@ -2,11 +2,8 @@
     "wire-plugin": [
         {
             "target": "\\Spryker\\Zed\\CmsContentWidget\\CmsContentWidgetDependencyProvider::getCmsContentWidgetParameterMapperPlugins",
-            "source": "\\Spryker\\Zed\\CmsContentWidgetProductConnector\\Communication\\Plugin\\Cms\\CmsProductSkuMapperPlugin"
-        },
-        {
-            "target": "\\Spryker\\Zed\\CmsContentWidget\\CmsContentWidgetDependencyProvider::getCmsContentWidgetParameterMapperPlugins",
-            "source": "\\Spryker\\Zed\\CmsContentWidgetProductConnector\\Communication\\Plugin\\Cms\\CmsProductSkuMapperPlugin"
+            "source": "\\Spryker\\Zed\\CmsContentWidgetProductConnector\\Communication\\Plugin\\Cms\\CmsProductSkuMapperPlugin",
+            "index": "\\Spryker\\Shared\\CmsContentWidgetProductConnector\\ContentWidgetConfigurationProvider\\CmsProductContentWidgetConfigurationProvider::FUNCTION_NAME"
         }
     ]
 }

--- a/SprykerShop/CmsContentWidgetProductSetConnector/1.0.0/installer-manifest.json
+++ b/SprykerShop/CmsContentWidgetProductSetConnector/1.0.0/installer-manifest.json
@@ -2,7 +2,8 @@
     "wire-plugin": [
         {
             "target": "\\Spryker\\Zed\\CmsContentWidget\\CmsContentWidgetDependencyProvider::getCmsContentWidgetParameterMapperPlugins",
-            "source": "\\Spryker\\Zed\\CmsContentWidgetProductSetConnector\\Communication\\Plugin\\Cms\\CmsProductSetKeyMapperPlugin"
+            "source": "\\Spryker\\Zed\\CmsContentWidgetProductSetConnector\\Communication\\Plugin\\Cms\\CmsProductSetKeyMapperPlugin",
+            "index": "\\Spryker\\Shared\\CmsContentWidgetProductSetConnector\\ContentWidgetConfigurationProvider\\CmsProductSetContentWidgetConfigurationProvider::FUNCTION_NAME"
         }
     ]
 }


### PR DESCRIPTION
Change log: 

- Fix the manifests for `CmsContentWidgetProductConnector` and `CmsContentWidgetProductSetConnector` modules. Array keys were missing.